### PR TITLE
Fixes for some errors

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const socketConnection = require('./application').socketConnection;
-const reset = require('./reset');
 
 const bodyParser = require('body-parser');
 const express = require('express');
@@ -27,8 +26,6 @@ app.get('/bundle.js', (req, res) => {
 });
 
 app.use(express.static(path.join(__dirname, '../', 'src', 'md5Crack')));
-
-app.post('/reset', reset);
 
 app.use((req, res) => {
   res.sendStatus(404);

--- a/src/Socket.js
+++ b/src/Socket.js
@@ -8,7 +8,7 @@ function disconnectSocket() {
 
 function initSocket(io) {
 	//returning a live socket connection
-	socket = io();
+	socket = io('http://' + window.location.hostname + ':3000');
 	return socket; 
 }
 

--- a/src/components/JoinSession.jsx
+++ b/src/components/JoinSession.jsx
@@ -8,6 +8,7 @@ import Success from './Success';
 import Host from './Host';
 import { initSocket, disconnectSocket } from '../Socket';
 import { startWorkers, terminateAllWorkers } from '../workerController';
+import io from 'socket.io-client';
 
 let socket;
 


### PR DESCRIPTION
I'm getting error while runing `npm start`
```
Error: Cannot find module './reset'
```
So I updated `server.js`

Then I get:
```
Uncaught ReferenceError: io is not defined
    at JoinSession.startSocketConnection (bundle.js:35015)
    at Participate.notifyServer (bundle.js:35467)
    at Object.ReactErrorUtils.invokeGuardedCallback (bundle.js:12304)
    at executeDispatch (bundle.js:12104)
    at Object.executeDispatchesInOrder (bundle.js:12127)
    at executeDispatchesAndRelease (bundle.js:11557)
    at executeDispatchesAndReleaseTopLevel (bundle.js:11568)
    at Array.forEach (<anonymous>)
    at forEachAccumulated (bundle.js:12404)
    at Object.processEventQueue (bundle.js:11773)
```
when I clicked `Yes` on `/JoinSession` page, so I provided additional import:
```
import io from 'socket.io-client';
```

but importing `io` wasn't enough, because it needs server URL, so I update `Socket.js` like that:
```
socket = io('http://' + window.location.hostname + ':3000');
```
however, I don't think it's the best solution. Server URL should be contained in `envs`, but these changes let me start demo 😉